### PR TITLE
add/edit plots

### DIFF
--- a/src/rail/plotting/data_extraction_funcs.py
+++ b/src/rail/plotting/data_extraction_funcs.py
@@ -67,6 +67,31 @@ def extract_z_point(
     z_estimates = np.squeeze(qp_ens.ancil[colname])
     return z_estimates
 
+def extract_mag(
+    filepath: str,
+    colname: str = "mag_lsst_i",
+) -> np.ndarray:
+    """Extract the i-mag from a file
+
+    Parameters
+    ----------
+    filepath: str
+        Path to file with tabular data
+
+    colname: str
+        Name of the column with redshfits ['redshift']
+
+    Returns
+    -------
+    magnitude: np.ndarray
+        Magnitude in question
+
+    Notes
+    -----
+    This assumes the magnitude are in a file that can be read by tables_io
+    """
+    magnitude_table = tables_io.read(filepath)
+    return magnitude_table[colname]
 
 def extract_z_pdf(
     filepath: str,
@@ -144,6 +169,35 @@ def make_z_true_z_point_dict(
     )
     return out_dict
 
+def make_z_true_z_point_mag_dict(
+    z_true: np.ndarray,
+    z_estimate: np.ndarray,
+    mag: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Build a dictionary with true redshifts and a point_estimates
+
+    Parameters
+    ----------
+    z_true: np.ndarray
+        True Redshifts
+
+    z_estimate: np.ndarray
+        Point estimates
+
+    mag: np.ndarray
+        Magnitude
+        
+    Returns
+    -------
+    out_dict: dict[str, np.ndarray]
+        Dictionary with true redshift and a point estimate of the redshift
+    """
+    out_dict: dict[str, Any] = dict(
+        truth=z_true,
+        pointEstimate=z_estimate,
+        magnitude=mag
+    )
+    return out_dict
 
 def make_z_true_multi_z_point_dict(
     z_true: np.ndarray,
@@ -356,7 +410,8 @@ def get_pz_point_estimate_data(
         return None
     z_true_data = extract_z_true(z_true_path)
     z_estimate_data = extract_z_point(z_estimate_path)
-    pz_data = make_z_true_z_point_dict(z_true_data, z_estimate_data)
+    mag_data = extract_mag(z_true_path)
+    pz_data = make_z_true_z_point_dict(z_true_data, z_estimate_data, mag_data)
     return pz_data
 
 

--- a/src/rail/plotting/data_extraction_funcs.py
+++ b/src/rail/plotting/data_extraction_funcs.py
@@ -67,9 +67,10 @@ def extract_z_point(
     z_estimates = np.squeeze(qp_ens.ancil[colname])
     return z_estimates
 
+
 def extract_mag(
     filepath: str,
-    colname: str = "mag_lsst_i",
+    colname: str = "LSST_obs_i",
 ) -> np.ndarray:
     """Extract the i-mag from a file
 
@@ -92,6 +93,7 @@ def extract_mag(
     """
     magnitude_table = tables_io.read(filepath)
     return magnitude_table[colname]
+
 
 def extract_z_pdf(
     filepath: str,
@@ -147,16 +149,20 @@ def extract_multiple_z_point(
 def make_z_true_z_point_dict(
     z_true: np.ndarray,
     z_estimate: np.ndarray,
+    mags: np.ndarray,
 ) -> dict[str, np.ndarray]:
     """Build a dictionary with true redshifts and a point_estimates
 
     Parameters
     ----------
-    z_true: np.ndarray
+    z_true:
         True Redshifts
 
-    z_estimate: np.ndarray
+    z_estimate:
         Point estimates
+
+    mags:
+        Magnitdues
 
     Returns
     -------
@@ -166,38 +172,10 @@ def make_z_true_z_point_dict(
     out_dict: dict[str, Any] = dict(
         truth=z_true,
         pointEstimate=z_estimate,
+        magnitude=mags,
     )
     return out_dict
 
-def make_z_true_z_point_mag_dict(
-    z_true: np.ndarray,
-    z_estimate: np.ndarray,
-    mag: np.ndarray,
-) -> dict[str, np.ndarray]:
-    """Build a dictionary with true redshifts and a point_estimates
-
-    Parameters
-    ----------
-    z_true: np.ndarray
-        True Redshifts
-
-    z_estimate: np.ndarray
-        Point estimates
-
-    mag: np.ndarray
-        Magnitude
-        
-    Returns
-    -------
-    out_dict: dict[str, np.ndarray]
-        Dictionary with true redshift and a point estimate of the redshift
-    """
-    out_dict: dict[str, Any] = dict(
-        truth=z_true,
-        pointEstimate=z_estimate,
-        magnitude=mag
-    )
-    return out_dict
 
 def make_z_true_multi_z_point_dict(
     z_true: np.ndarray,

--- a/src/rail/plotting/pz_plotters.py
+++ b/src/rail/plotting/pz_plotters.py
@@ -12,6 +12,12 @@ from .dataset_holder import RailDatasetHolder
 from .plot_holder import RailPlotHolder
 from .plotter import RailPlotter
 
+import matplotlib.colors as colors
+from astropy.stats import biweight_location, biweight_scale
+from scipy.stats import sigmaclip
+
+
+
 
 class RailPZPointEstimateDataset(RailDataset):
     """Dataet to hold a vector p(z) point estimates and corresponding
@@ -21,6 +27,7 @@ class RailPZPointEstimateDataset(RailDataset):
     data_types = dict(
         truth=np.ndarray,
         pointEstimate=np.ndarray,
+        magnitude=np.ndarray
     )
 
 
@@ -45,9 +52,11 @@ class PZPlotterPointEstimateVsTrueHist2D(RailPlotter):
         z_min=StageParameter(float, 0.0, fmt="%0.2f", msg="Minimum Redshift"),
         z_max=StageParameter(float, 3.0, fmt="%0.2f", msg="Maximum Redshift"),
         n_zbins=StageParameter(int, 150, fmt="%i", msg="Number of z bins"),
+        n_clip=StageParameter(int, 3, fmt="%i", msg="Number of sigma cliping for outliers")
     )
 
     input_type = RailPZPointEstimateDataset
+
 
     def _make_2d_hist_plot(
         self,
@@ -56,18 +65,40 @@ class PZPlotterPointEstimateVsTrueHist2D(RailPlotter):
         pointEstimate: np.ndarray,
         dataset_holder: RailDatasetHolder | None = None,
     ) -> RailPlotHolder:
-        figure, axes = plt.subplots()
+        figure, axes = plt.subplots(figsize = (7,6))
         bin_edges = np.linspace(
             self.config.z_min, self.config.z_max, self.config.n_zbins + 1
         )
-        axes.hist2d(
+        dz = (pointEstimate - truth)/(1+truth)
+        mean, mean_err, std, outlier_rate = self.get_biweight_mean_sigma_outlier(dz, nclip = self.config.n_clip)
+        mean, std, outlier_rate = round(mean,4),round(std,4),round(outlier_rate,4)
+        print(mean, mean_err, std, outlier_rate)
+        h = axes.hist2d(
             truth,
             pointEstimate,
             bins=(bin_edges, bin_edges),
+            norm=colors.LogNorm(),
+            cmap = 'gray'
         )
+        alpha = 1
+        axes.plot([self.config.z_min-10, self.config.z_max+10], [self.config.z_min-10, self.config.z_max+10], '--',
+                  color = 'red')
+        axes.plot([self.config.z_min-10, self.config.z_max+10], [self.config.z_min-10-3*std, self.config.z_max+10-3*std], '--',
+                  color = 'red')
+        axes.plot([self.config.z_min-10, self.config.z_max+10], [self.config.z_min-10+3*std,  self.config.z_max+10+3*std], '--',
+                  color = 'red')
+        axes.plot([],[], '.', alpha =0.0, label = rf"$\Delta z = {mean} $" + "\n" + rf"$\sigma z = {std} $"+ "\n" +f"outlier rate = {outlier_rate}")
+
+        
         plt.xlabel("True Redshift")
         plt.ylabel("Estimated Redshift")
+        cb = figure.colorbar(h[3], ax=axes)
+        cb.set_label('Density')
+        
+        plt.legend()
+        
         plot_name = self._make_full_plot_name(prefix, "")
+        
         return RailPlotHolder(
             name=plot_name, figure=figure, plotter=self, dataset_holder=dataset_holder
         )
@@ -97,7 +128,20 @@ class PZPlotterPointEstimateVsTrueHist2D(RailPlotter):
             )
         out_dict[plot.name] = plot
         return out_dict
+    
+    def get_biweight_mean_sigma_outlier(self, subset, nclip = 3):
+    subset_clip, _, _ = sigmaclip(subset, low=3, high=3)
+    for j in range(nclip):
 
+        subset_clip, _, _ = sigmaclip(subset_clip, low=3, high=3)
+    
+    mean = biweight_location(subset_clip)
+    std = biweight_scale(subset_clip)
+    outlier_rate = np.sum(np.abs(subset)>3*biweight_scale(subset_clip))/len(subset)
+    
+    return  mean, std/np.sqrt(len(subset_clip)), std, outlier_rate
+
+    
 
 class PZPlotterPointEstimateVsTrueProfile(RailPlotter):
     """Class to make a profile plot of p(z) point estimates
@@ -246,3 +290,322 @@ class PZPlotterAccuraciesVsTrue(RailPlotter):
             plot = self._make_accuracy_plot(prefix=prefix, **kwargs)
         out_dict[plot.name] = plot
         return out_dict
+
+    
+
+
+class PZPlotterBiweightStatsVsRedshift(RailPlotter):
+    """Class to make a 2D histogram of p(z) point estimates
+    versus true redshift
+    """
+
+    config_options: dict[str, StageParameter] = RailPlotter.config_options.copy()
+    config_options.update(
+        z_min=StageParameter(float, 0.0, fmt="%0.2f", msg="Minimum Redshift"),
+        z_max=StageParameter(float, 3.0, fmt="%0.2f", msg="Maximum Redshift"),
+        n_zbins=StageParameter(int, 15, fmt="%i", msg="Number of z bins"),
+        n_clip=StageParameter(int, 3, fmt="%i", msg="Number of sigma cliping for outliers"),
+    )
+
+    input_type = RailPZPointEstimateDataset
+
+    def _make_biweight_stats_plot(
+        self,
+        prefix: str,
+        truth: np.ndarray,
+        pointEstimate: np.ndarray,
+        dataset_holder: RailDatasetHolder | None = None,
+    ) -> RailPlotHolder:
+        
+        dz = (pointEstimate - truth)/(1+truth)
+        
+        results = self.process_data(pointEstimate, 
+                                      truth, nbin = self.config.n_zbins,
+                                        low = self.config.z_min, high = self.config.z_max,
+                                         nclip = self.config.n_clip)
+        figure, axes = plt.subplots(2,1,figsize = (8,6))
+        
+        plt.subplots_adjust(wspace=0.1, hspace=0.0)
+        
+        axes[0].errorbar(results['z_mean'], results['biweight_mean'], results['biweight_std'], label = 'Bias')
+
+        axes[0].plot(results['z_mean'], results['biweight_sigma'], label = r'$\sigma_z$')
+
+        axes[0].plot(results['z_mean'], results['biweight_outlier'], label = r'Outlier rate')
+        axes[0].set_title(f'Bias, Sigma, and Outlier rates w/ {self.config.n_clip} sigma clipping')
+        axes[0].set_ylabel(f'Statistics')
+        axes[0].legend()
+        axes[0].tick_params(axis='x', which='both', bottom=False, top=False, labelbottom=False)
+        axes[0].set_xlim(self.config.z_min, self.config.z_max)
+        
+        
+        bin_edges_z = np.linspace(
+            self.config.z_min, self.config.z_max, 100 + 1
+        )
+        bin_edges_dz = np.linspace(
+            np.min(dz),  np.max(dz), 100 + 1
+        )
+        axes[1].hist2d(pointEstimate, dz,
+                    bins=(bin_edges_z, bin_edges_dz),
+                    norm=colors.LogNorm(),
+                    cmap = 'gray')
+        
+        
+        
+        axes[1].set_xlim(self.config.z_min, self.config.z_max)
+        for qt in ['qt_95_low', 'qt_68_low', 'median', 'qt_68_high', 'qt_95_high']:
+            axes[1].plot(results['z_mean'], results[qt], '--', color = 'blue', linewidth = 2.0)
+        
+        
+        axes[1].set_xlabel('Redshift')
+        axes[1].set_ylabel(r'$(z_{phot} - z_{spec})/(1+z_{spec})$')
+        plot_name = self._make_full_plot_name(prefix, "")
+        return RailPlotHolder(
+            name=plot_name, figure=figure, plotter=self, dataset_holder=dataset_holder
+        )
+
+    def _make_plots(self, prefix: str, **kwargs: Any) -> dict[str, RailPlotHolder]:
+        find_only = kwargs.get("find_only", False)
+        figtype = kwargs.get("figtype", "png")
+        dataset_holder = kwargs.get("dataset_holder")
+        out_dict: dict[str, RailPlotHolder] = {}
+        truth: np.ndarray = kwargs["truth"]
+        pointEstimate: np.ndarray = kwargs["pointEstimate"]
+        if find_only:
+            plot_name = self._make_full_plot_name(prefix, "")
+            assert dataset_holder
+            plot = RailPlotHolder(
+                name=plot_name,
+                path=os.path.join(dataset_holder.config.name, f"{plot_name}.{figtype}"),
+                plotter=self,
+                dataset_holder=dataset_holder,
+            )
+        else:
+            plot = self._make_biweight_stats_plot(
+                prefix=prefix,
+                truth=truth,
+                pointEstimate=pointEstimate,
+                dataset_holder=dataset_holder,
+            )
+        out_dict[plot.name] = plot
+        return out_dict
+
+    
+    def process_data(self, zphot, specz, low = 0.01, high = 2, nclip = 3, nbin = 101 ):
+        dz = (zphot - specz)/(1+specz)
+
+        z_bins = np.linspace(low, high, nbin)
+        # Bin the data
+        bin_indices = np.digitize(zphot, bins=z_bins) - 1  # Assign each point to a bin
+
+        biweight_mean = []
+        biweight_std = []
+        biweight_sigma = []
+        biweight_outlier = []
+        z_mean = []
+        qt_95_low=[] 
+        qt_68_low=[] 
+        median=[] 
+        qt_68_high=[] 
+        qt_95_high=[] 
+        for i in range(len(z_bins) - 1):
+            
+            subset = dz[bin_indices == i]
+            if len(subset)<1:
+                continue
+            subset_clip, _, _ = sigmaclip(subset, low=3, high=3)
+            for j in range(nclip):
+
+                subset_clip, _, _ = sigmaclip(subset_clip, low=3, high=3)
+
+
+            biweight_mean.append(biweight_location(subset_clip))
+            biweight_std.append(biweight_scale(subset_clip)/np.sqrt(len(subset_clip)))
+            biweight_sigma.append(biweight_scale(subset_clip))
+
+            
+
+            outlier_rate = np.sum(np.abs(subset)>3*biweight_scale(subset_clip))/len(subset)
+            biweight_outlier.append(outlier_rate)
+            
+            qt_95_low.append(np.percentile(subset, 2.5))
+            qt_68_low.append(np.percentile(subset, 16))
+            median.append(np.percentile(subset, 50))
+            qt_68_high.append(np.percentile(subset, 84))
+            qt_95_high.append(np.percentile(subset, 97.5))
+            
+            z_mean.append(np.mean(zphot[bin_indices == i]))
+            
+            
+        return {"z_mean" : z_mean, 
+                "biweight_mean" : biweight_mean, 
+                "biweight_std" : biweight_std, 
+                "biweight_sigma" : biweight_sigma, 
+                "biweight_outlier" : biweight_outlier,
+                "qt_95_low" : qt_95_low, 
+                "qt_68_low" : qt_68_low, 
+                "median" : median, 
+                "qt_68_high" : qt_68_high, 
+                "qt_95_high" : qt_95_high, 
+                   }
+
+
+class PZPlotterBiweightStatsVsMag(RailPlotter):
+    """Class to make a 2D histogram of p(z) point estimates
+    versus true redshift
+    """
+
+    config_options: dict[str, StageParameter] = RailPlotter.config_options.copy()
+    config_options.update(
+        mag_min=StageParameter(float, 18, fmt="%0.2f", msg="Minimum Magnitude"),
+        mag_max=StageParameter(float, 25, fmt="%0.2f", msg="Maximum Magnitude"),
+        n_magbins=StageParameter(int, 10, fmt="%i", msg="Number of magnitude bins"),
+        n_clip=StageParameter(int, 3, fmt="%i", msg="Number of sigma cliping for outliers"),
+    )
+
+    input_type = RailPZPointEstimateDataset
+
+    def _make_biweight_stats_plot(
+        self,
+        prefix: str,
+        truth: np.ndarray,
+        pointEstimate: np.ndarray,
+        magnitude: np.ndarray,
+        dataset_holder: RailDatasetHolder | None = None,
+    ) -> RailPlotHolder:
+        
+        dz = (pointEstimate - truth)/(1+truth)
+        
+        results = self.process_data(pointEstimate, 
+                                      truth, magnitude, nbin = self.config.n_magbins,
+                                        low = self.config.mag_min, high = self.config.mag_max,
+                                         nclip = self.config.n_clip)
+        figure, axes = plt.subplots(2,1,figsize = (8,6))
+        
+        plt.subplots_adjust(wspace=0.1, hspace=0.0)
+        
+        axes[0].errorbar(results['mag_mean'], results['biweight_mean'], results['biweight_std'], label = 'Bias')
+
+        axes[0].plot(results['mag_mean'], results['biweight_sigma'], label = r'$\sigma_z$')
+
+        axes[0].plot(results['mag_mean'], results['biweight_outlier'], label = r'Outlier rate')
+        axes[0].set_title(f'Bias, Sigma, and Outlier rates w/ {self.config.n_clip} sigma clipping')
+        axes[0].set_ylabel(f'Statistics')
+        axes[0].legend()
+        axes[0].tick_params(axis='x', which='both', bottom=False, top=False, labelbottom=False)
+        axes[0].set_xlim(self.config.mag_min, self.config.mag_max)
+        
+        
+        bin_edges_mag = np.linspace(
+            self.config.mag_min, self.config.mag_max, 100 + 1
+        )
+        bin_edges_dz = np.linspace(
+            np.min(dz),  np.max(dz), 100 + 1
+        )
+        axes[1].hist2d(magnitude, dz,
+                    bins=(bin_edges_mag, bin_edges_dz),
+                    norm=colors.LogNorm(),
+                    cmap = 'gray')
+        
+        
+        
+        axes[1].set_xlim(self.config.mag_min, self.config.mag_max)
+        for qt in ['qt_95_low', 'qt_68_low', 'median', 'qt_68_high', 'qt_95_high']:
+            axes[1].plot(results['mag_mean'], results[qt], '--', color = 'blue', linewidth = 2.0)
+        
+        
+        axes[1].set_xlabel('Magnitude')
+        axes[1].set_ylabel(r'$(z_{phot} - z_{spec})/(1+z_{spec})$')
+
+        plot_name = self._make_full_plot_name(prefix, "")
+        
+        return RailPlotHolder(
+            name=plot_name, figure=figure, plotter=self, dataset_holder=dataset_holder
+        )
+
+    def _make_plots(self, prefix: str, **kwargs: Any) -> dict[str, RailPlotHolder]:
+        find_only = kwargs.get("find_only", False)
+        figtype = kwargs.get("figtype", "png")
+        dataset_holder = kwargs.get("dataset_holder")
+        out_dict: dict[str, RailPlotHolder] = {}
+        truth: np.ndarray = kwargs["truth"]
+        pointEstimate: np.ndarray = kwargs["pointEstimate"]
+        magnitude: np.ndarray=kwargs["magnitude"]
+        if find_only:
+            plot_name = self._make_full_plot_name(prefix, "")
+            assert dataset_holder
+            plot = RailPlotHolder(
+                name=plot_name,
+                path=os.path.join(dataset_holder.config.name, f"{plot_name}.{figtype}"),
+                plotter=self,
+                dataset_holder=dataset_holder,
+            )
+        else:
+            plot = self._make_biweight_stats_plot(
+                prefix=prefix,
+                truth=truth,
+                pointEstimate=pointEstimate,
+                magnitude=magnitude,
+                dataset_holder=dataset_holder,
+            )
+        out_dict[plot.name] = plot
+        return out_dict
+
+    
+    def process_data(self, zphot, specz, mag, low = 0.01, high = 2, nclip = 3, nbin = 101 ):
+        dz = (zphot - specz)/(1+specz)
+
+        mag_bins = np.linspace(low, high, nbin)
+        # Bin the data
+        bin_indices = np.digitize(mag, bins=mag_bins) - 1  # Assign each point to a bin
+
+        biweight_mean = []
+        biweight_std = []
+        biweight_sigma = []
+        biweight_outlier = []
+        
+        qt_95_low=[] 
+        qt_68_low=[] 
+        median=[] 
+        qt_68_high=[] 
+        qt_95_high=[] 
+        for i in range(len(mag_bins) - 1):
+
+            subset = dz[bin_indices == i]
+            subset_clip, _, _ = sigmaclip(subset, low=3, high=3)
+            for j in range(nclip):
+
+                subset_clip, _, _ = sigmaclip(subset_clip, low=3, high=3)
+
+
+            biweight_mean.append(biweight_location(subset_clip))
+            biweight_std.append(biweight_scale(subset_clip)/np.sqrt(len(subset_clip)))
+            biweight_sigma.append(biweight_scale(subset_clip))
+
+            
+
+            outlier_rate = np.sum(np.abs(subset)>3*biweight_scale(subset_clip))/len(subset)
+            biweight_outlier.append(outlier_rate)
+            
+            qt_95_low.append(np.percentile(subset, 2.5))
+            qt_68_low.append(np.percentile(subset, 16))
+            median.append(np.percentile(subset, 50))
+            qt_68_high.append(np.percentile(subset, 84))
+            qt_95_high.append(np.percentile(subset, 97.5))
+            
+
+        mag_mean = (mag_bins[:-1] + mag_bins[1:])/2
+
+        return {"mag_mean" : mag_mean, 
+                "biweight_mean" : biweight_mean, 
+                "biweight_std" : biweight_std, 
+                "biweight_sigma" : biweight_sigma, 
+                "biweight_outlier" : biweight_outlier,
+                "qt_95_low" : qt_95_low, 
+                "qt_68_low" : qt_68_low, 
+                "median" : median, 
+                "qt_68_high" : qt_68_high, 
+                "qt_95_high" : qt_95_high, 
+                   }
+    
+        

--- a/src/rail/projects/reducer.py
+++ b/src/rail/projects/reducer.py
@@ -173,9 +173,9 @@ class RomanRubinReducer(RailReducer):
     ) -> None:
         # FIXME: do this right
         if self.config.cuts:
-            if 'maglim_i' in self.config.cuts:
+            if "maglim_i" in self.config.cuts:
                 predicate = pc.field("LSST_obs_i") < self.config.cuts["maglim_i"][1]
-            elif 'maglim_Y' in self.config.cuts:
+            elif "maglim_Y" in self.config.cuts:
                 predicate = pc.field("ROMAN_obs_Y106") < self.config.cuts["maglim_Y"][1]
             else:
                 raise ValueError("No valid cut")

--- a/tests/ci_plot_groups.yaml
+++ b/tests/ci_plot_groups.yaml
@@ -23,6 +23,14 @@ PlotGroups:
       plotter_list_name: accuracy_v_ztrue
       dataset_list_name: baseline_merged
 
+
+  # Make plots of biweight stags
+  - PlotGroup:
+      name: biweight_stats
+      plotter_list_name: biweight_stats
+      dataset_list_name: baseline_test
+
+
   # Make plots of n(z) in various tomographic bins
   - PlotGroup:
       name: tomo_bins

--- a/tests/ci_plots.yaml
+++ b/tests/ci_plots.yaml
@@ -26,6 +26,27 @@ Plots:
         - zestimate_v_ztrue_hist2d
         - zestimate_v_ztrue_profile
 
+  # A plot of biweight stats v redshift
+  - Plotter:
+      name: biweight_stats_v_redshift
+      class_name: rail.plotting.pz_plotters.PZPlotterBiweightStatsVsRedshift
+
+
+  # A plot of biweight stats v magnitdue
+  - Plotter:
+      name: biweight_stats_v_magnitude
+      class_name: rail.plotting.pz_plotters.PZPlotterBiweightStatsVsMag
+
+  # This combines the two previous plots, since they used the same type of data
+  # they can be made together
+  - PlotterList:
+      name: biweight_stats
+      dataset_holder_class: rail.plotting.pz_data_holders.RailPZPointEstimateDataHolder
+      plotters:
+        - biweight_stats_v_redshift
+        - biweight_stats_v_magnitude
+
+
   # Plot the accuracy v. redshift for a set of point estimates
   - Plotter:
       name: accuracy_v_ztrue

--- a/tests/cli/project/test_project_cli.py
+++ b/tests/cli/project/test_project_cli.py
@@ -89,11 +89,11 @@ def test_cli_subsample() -> None:
 def test_cli_run(pipeline: str) -> None:
     runner = CliRunner()
 
-    if pipeline == 'estimate':
+    if pipeline == "estimate":
         label_str = "--input_tag test "
     else:
         label_str = ""
-        
+
     result = runner.invoke(
         project_cli,
         f"run {pipeline} --selection gold --flavor baseline {label_str}--run_mode dry_run tests/ci_project.yaml",


### PR DESCRIPTION
Refresh the spec-z vs. photo-z plot
Add new plots:
(1) biweight bias, standard deviation, outlier rates vs. redshift
(2) biweight bias, standard deviation, outlier rates vs. magnitude

For that, we need the pz data holder to get the magnitude data from the input catalog


## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
