### PR TITLE
Fix biweighted plot

### DIFF
--- a/src/rail/plotting/pz_plotters.py
+++ b/src/rail/plotting/pz_plotters.py
@@ -443,10 +443,11 @@ class PZPlotterBiweightStatsVsRedshift(RailPlotter):
         z_bins = np.linspace(low, high, nbin)
         # Bin the data
         if self.config.zbin_type == 'spec':
-            bin_indices = np.digitize(specz, bins=z_bins) - 1  # Assign each point to a bin
+            zx = specz
         else:
-            bin_indices = np.digitize(zphot, bins=z_bins) - 1  # Assign each point to a bin
+            zx = zphot
 
+        bin_indices = np.digitize(zx, bins=z_bins) - 1  # Assign each point to a bin
         biweight_mean: list[float] = []
         biweight_std: list[float] = []
         biweight_sigma: list[float] = []
@@ -480,7 +481,7 @@ class PZPlotterBiweightStatsVsRedshift(RailPlotter):
             qt_68_high.append(np.percentile(subset, 84))
             qt_95_high.append(np.percentile(subset, 97.5))
 
-            z_mean.append(np.mean(zphot[bin_indices == i]))
+            z_mean.append(np.mean(zx[bin_indices == i]))
 
         return {
             "z_mean": z_mean,


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

All that's needed is to change the zmean based on the z-type
## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
