### PR TITLE
Fix for file_aliases in Flavors #42

### DIFF
--- a/src/rail/projects/pipeline_holder.py
+++ b/src/rail/projects/pipeline_holder.py
@@ -484,6 +484,8 @@ def pz_input_callback(
     flavor = kwargs.pop("flavor")
     for key, val in input_file_tags.items():
         input_file_flavor = val.get("flavor", flavor)
+        if input_file_flavor!=flavor:
+            input_file_flavor=flavor
         input_files[key] = project.get_file_for_flavor(
             input_file_flavor, val["tag"], **kwargs
         )


### PR DESCRIPTION
Addresses #42, I tested this at NERSC and the code does respect `file_aliases` in flavors with this change

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
