### PR TITLE
add halo mass, stellar mass, and sfr to roman-rubin columns

### DIFF
--- a/src/rail/projects/reducer.py
+++ b/src/rail/projects/reducer.py
@@ -41,6 +41,9 @@ COLUMNS = [
     "diskHalfLightRadiusArcsec",
     "spheroidHalfLightRadiusArcsec",
     "bulge_frac",
+    "sod_halo_mass",
+    "logsm_obs",
+    "sfr"
     # "healpix",
 ]
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
