### PR TITLE
Added mechanism to read external catalog library

### DIFF
--- a/src/rail/projects/pipeline_holder.py
+++ b/src/rail/projects/pipeline_holder.py
@@ -8,6 +8,7 @@ from ceci.config import StageParameter
 from rail.core.configurable import Configurable
 from rail.core.stage import RailPipeline
 from rail.utils import catalog_utils
+from rail.utils.catalog_tag import CatalogTag
 
 if TYPE_CHECKING:
     from .project import RailProject
@@ -820,10 +821,12 @@ class RailPipelineInstance(Configurable):
         catalog_tag = project.get_flavor(self.config.flavor).get("catalog_tag", None)
         if catalog_tag:
             try:
-                catalog_utils.apply_defaults(catalog_tag)
-            except KeyError:  # pragma: no cover
+                CatalogTag.apply(catalog_tag)
+            except KeyError as msg:  # pragma: no cover
                 tokens = catalog_tag.split(".")
                 module_name = ".".join(tokens[:-1])
+                if not module_name:
+                    raise ValueError(f"Could not find {catalog_tag}")
                 class_name = tokens[-1]
                 __import__(module_name)
                 catalog_utils.CatalogConfigBase.apply_class(class_name)

--- a/src/rail/projects/project.py
+++ b/src/rail/projects/project.py
@@ -8,6 +8,7 @@ import yaml
 from ceci.config import StageParameter
 from rail.core.configurable import Configurable
 from rail.core.model import Model
+from rail.utils import catalog_utils
 
 from . import execution, library, name_utils
 from .algorithm_factory import RailAlgorithmFactory
@@ -85,6 +86,7 @@ class RailProject(Configurable):  # pylint: disable=too-many-public-methods
     config_options: dict[str, StageParameter] = dict(
         Name=StageParameter(str, None, fmt="%s", required=True, msg="Project name"),
         SiteConfig=StageParameter(dict, {}, fmt="%s", msg="Site configuration options"),
+        CatalogLib=StageParameter(list, [], fmt="%s", msg="Libraries of catalog tags"),
         Includes=StageParameter(list, [], fmt="%s", msg="Files to include"),
         Baseline=StageParameter(
             dict, None, fmt="%s", required=True, msg="Baseline analysis configuration"
@@ -614,6 +616,13 @@ class RailProject(Configurable):  # pylint: disable=too-many-public-methods
         int:
             0 if ok, error code otherwise
         """
+        catalog_utils.clear()
+        if self.config.CatalogLib:
+            for catalog_lib in self.config.CatalogLib:
+                catalog_utils.load_yaml(catalog_lib)
+        else:            
+            catalog_utils.load_yaml(catalog_utils.DEFAULT_CATAlOG_TAG_FILE)
+        
         flavor_dict = self.get_flavor(flavor)
         pipelines_to_build = flavor_dict["pipelines"]
         all_flavor_overrides = flavor_dict.get("pipeline_overrides", {}).copy()

--- a/tests/ci_project.yaml
+++ b/tests/ci_project.yaml
@@ -2,6 +2,10 @@ Project:
 
   Name: ci_test
 
+  # Catalog Library
+  CatalogLib: 
+    - tests/default_catalogs.yaml
+
   # Include other configuration files
   Includes:
     - tests/ci_project_library.yaml

--- a/tests/default_catalogs.yaml
+++ b/tests/default_catalogs.yaml
@@ -1,0 +1,158 @@
+# Information about a filter bands
+# For each band this is just a name and a reddening
+# parameter: a_env.   
+
+# The name is used for lookup and should be unique.
+# It should match the name of the associated filter file.
+#
+# These are typically found in:
+# rail_base/src/rail/examples_data/estimation_data/data/FILTER
+#
+# The a_env parameter can be computed from filter 
+# curves using code in `rail_astro_tools`:
+#
+# https://github.com/LSSTDESC/rail_astro_tools/blob/main/src/rail/tools/filter_tools.py
+Bands:
+  - Band:
+      name: comcam_u
+      a_env: 4.81
+  - Band:
+      name: comcam_g
+      a_env: 3.64
+  - Band:
+      name: comcam_r
+      a_env: 2.70
+  - Band:
+      name: comcam_i
+      a_env: 2.06
+  - Band:
+      name: comcam_z
+      a_env: 1.58
+  - Band:
+      name: comcam_y
+      a_env: 1.31
+  - Band:
+      name: DC2LSST_u
+      a_env: 4.81
+  - Band:
+      name: DC2LSST_g
+      a_env: 3.64
+  - Band:
+      name: DC2LSST_r
+      a_env: 2.70
+  - Band:
+      name: DC2LSST_i
+      a_env: 2.06
+  - Band:
+      name: DC2LSST_z
+      a_env: 1.58
+  - Band:
+      name: DC2LSST_y
+      a_env: 1.31
+  - Band:
+      name: euclid_H
+      a_env: 0.47
+  - Band:
+      name: euclid_J
+      a_env: 0.76
+  - Band:
+      name: euclid_Y
+      a_env: 1.10
+  - Band:
+      name: euclid_vis
+      a_env: 2.24
+  - Band:
+      name: hsc_g
+      a_env: 3.64
+  - Band:
+      name: hsc_r
+      a_env: 2.70
+  - Band:
+      name: hsc_i
+      a_env: 2.06
+  - Band:
+      name: hsc_z
+      a_env: 1.58
+  - Band:
+      name: hsc_y
+      a_env: 1.31
+  - Band:
+      name: roman_K213
+      a_env: 0.37
+  - Band:
+      name: roman_F184
+      a_env: 0.47
+  - Band:
+      name: roman_H158
+      a_env: 0.60
+  - Band:
+      name: roman_W146
+      a_env: 0.68
+  - Band:
+      name: roman_J129
+      a_env: 0.83
+  - Band:
+      name: roman_Y106
+      a_env: 1.14
+  - Band:
+      name: roman_Z087
+      a_env: 1.57
+# These are just copied from the comcam values and should be updated
+  - Band:
+      name: DECam_g
+      a_env: 3.64
+  - Band:
+      name: DECam_r
+      a_env: 2.70
+  - Band:
+      name: DECam_i
+      a_env: 2.06
+  - Band:
+      name: DECam_z
+      a_env: 1.58
+  - Band:
+      name: DECam_y
+      a_env: 1.31
+      
+#
+# Particulars about specific catalogs.
+# 
+# These keep track of things like the mapping between band names and columns,
+# names of special columns like the objectId and the 'true' redshift, guard
+# values used to specify non-detections or non-observations.
+#
+# The mapping between bands and magnitude, magnitude error columns
+# is constructed by looping over the band_list add resolving
+# mag_column_template and mag_err_column_template.
+#
+# Similarly, the mapping between bands and filters is constructed
+# by looping over the band_list add resolving filter_template.
+#
+# The `bands` field is used to provide band-specific overrides.
+# At a minimum this must include 5-sigma limiting magnitdues.
+#
+# But it may also include specfic overrides for the names of the
+# mag_column, mag_err_columns and filter template file, for example when a
+# subset of band_list entries do not follow the patterns in the templates.
+#
+CatalogTags:
+  - CatalogTag:
+      name: "roman_rubin"
+      mag_column_template: "LSST_obs_{band}"
+      mag_err_column_template: "LSST_obs_{band}_err"
+      redshift_col: "true_redshift"
+      filter_template: "DC2LSST_{band}"
+      band_list: ['u', 'g', 'r', 'i', 'z', 'y']
+      bands:
+        u:
+          mag_limit: 24.0
+        g:
+          mag_limit: 27.66
+        r:
+          mag_limit: 27.25
+        i:
+          mag_limit: 26.6
+        z:
+          mag_limit: 26.24
+        y:
+          mag_limit: 23.35


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
