### PR TITLE
implement cosmos multiband photometric redshift selector

### DIFF
--- a/examples/cardinal_project_library.yaml
+++ b/examples/cardinal_project_library.yaml
@@ -91,6 +91,14 @@ SpecSelections:
       name: zCOSMOS
       Select: SpecSelection_zCOSMOS
       Module: rail.creation.degraders.spectroscopic_selections
+  - SpecSelection:
+      name: gaussian_skewt_scatter
+      Select: GaussianSkewtScatterSelector
+      Module: rail.creation.degraders.gaussian_skewt_scatter_selector
+      Overrides:
+        col_name: redshift_manyband
+        col_name_mag_i: mag_i_lsst
+        col_name_z: redshift
 
 
 # These describe all the algorithms that estimate PZ

--- a/examples/cardinal_project_library.yaml
+++ b/examples/cardinal_project_library.yaml
@@ -92,7 +92,7 @@ SpecSelections:
       Select: SpecSelection_zCOSMOS
       Module: rail.creation.degraders.spectroscopic_selections
   - SpecSelection:
-      name: gaussian_skewt_scatter
+      name: COSMOS2020
       Select: GaussianSkewtScatterSelector
       Module: rail.creation.degraders.gaussian_skewt_scatter_selector
       Overrides:

--- a/examples/flagship_project_library.yaml
+++ b/examples/flagship_project_library.yaml
@@ -88,7 +88,14 @@ SpecSelections:
       name: zCOSMOS
       Select: SpecSelection_zCOSMOS
       Module: rail.creation.degraders.spectroscopic_selections
-
+  - SpecSelection:
+      name: gaussian_skewt_scatter
+      Select: GaussianSkewtScatterSelector
+      Module: rail.creation.degraders.gaussian_skewt_scatter_selector
+      Overrides:
+        col_name: redshift_manyband
+        col_name_mag_i: mag_i_lsst
+        col_name_z: redshift
 
 # These describe all the algorithms that estimate PZ
 PZAlgorithms:

--- a/examples/flagship_project_library.yaml
+++ b/examples/flagship_project_library.yaml
@@ -89,7 +89,7 @@ SpecSelections:
       Select: SpecSelection_zCOSMOS
       Module: rail.creation.degraders.spectroscopic_selections
   - SpecSelection:
-      name: gaussian_skewt_scatter
+      name: COSMOS2020
       Select: GaussianSkewtScatterSelector
       Module: rail.creation.degraders.gaussian_skewt_scatter_selector
       Overrides:


### PR DESCRIPTION
add GaussianSkewtScatterSelector in cardinal/flagship yaml files

## Problem & Solution Description 

Add COSMOS2020 multiband photometric redshift emulator to rail_projects config files for Cardinal and Flagship simulations.